### PR TITLE
Refactor UnitOfWork to use generic context parameter

### DIFF
--- a/Jezda.Common.Data/UnitOfWork.cs
+++ b/Jezda.Common.Data/UnitOfWork.cs
@@ -9,17 +9,14 @@ using System.Threading.Tasks;
 
 namespace Jezda.Common.Data;
 
-public abstract class UnitOfWork : IUnitOfWork
+public abstract class UnitOfWork<TContext>(TContext context) : IUnitOfWork
+    where TContext : DbContext
 {
-    protected readonly DbContext _context;
+    protected readonly TContext _context = context ?? throw new ArgumentNullException(nameof(context));
+
     private IDbContextTransaction? _transaction;
     private bool _disposed = false;
     private readonly Dictionary<Type, Type> _repositories = new();
-
-    protected UnitOfWork(DbContext context)
-    {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
-    }
 
     // Abstract methods for microservices to implement
     protected abstract void ConfigureRepositories();


### PR DESCRIPTION
Updated UnitOfWork to be a generic class with a type parameter for the DbContext, improving type safety and flexibility. The constructor now directly assigns the context and enforces non-nullability.