### PR TITLE
fix(github): exclude pull requests from synced external tasks

### DIFF
--- a/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
+++ b/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
@@ -48,6 +48,17 @@ public sealed class GitHubIssue
 
     [JsonPropertyName("created_at")]
     public DateTimeOffset CreatedAt { get; set; }
+
+    // Present only when this item is a pull request. GitHub's issues endpoint
+    // returns PRs alongside issues; a non-null value marks the item as a PR.
+    [JsonPropertyName("pull_request")]
+    public GitHubPullRequestRef? PullRequest { get; set; }
+}
+
+public sealed class GitHubPullRequestRef
+{
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
 }
 
 public sealed class GitHubUser

--- a/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
+++ b/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
@@ -74,7 +74,9 @@ public sealed class GitHubTaskProvider(
             url = GetNextPageUrl(response);
         }
 
-        return [.. allIssues.Select(i => new ExternalTaskDto
+        return [.. allIssues
+            .Where(i => i.PullRequest is null) // GitHub's issues endpoint returns PRs too — keep only real issues
+            .Select(i => new ExternalTaskDto
         {
             Id = i.Number.ToString(),
             Title = i.Title,

--- a/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
@@ -94,6 +94,23 @@ public class GitHubTaskProviderTests
     }
 
     [Fact]
+    public async Task GetTasksAsync_ExcludesPullRequests()
+    {
+        var items = new object[]
+        {
+            new { id = 100L, number = 1, title = "Real issue", state = "open", html_url = "https://github.com/owner/repo/issues/1" },
+            new { id = 101L, number = 2, title = "A pull request", state = "open", html_url = "https://github.com/owner/repo/pull/2", pull_request = new { url = "https://api.github.com/repos/owner/repo/pulls/2" } }
+        };
+        _handler.EnqueueResponse(HttpStatusCode.OK, items);
+
+        var result = await _provider.GetTasksAsync("token", "owner/repo");
+
+        Assert.Single(result);
+        Assert.Equal("1", result[0].Id);
+        Assert.Equal("Real issue", result[0].Title);
+    }
+
+    [Fact]
     public async Task GetTasksAsync_RequestsAllStatesWithMaxPageSize()
     {
         _handler.EnqueueResponse(HttpStatusCode.OK, Array.Empty<object>());


### PR DESCRIPTION
## Problem
GitHub's `/repos/{owner}/{repo}/issues` endpoint returns pull requests alongside issues. The TMS GitHub provider had no filter, so PRs were synced as external tasks.

## Change
- `GitHubIssue` model: add `pull_request` (`GitHubPullRequestRef?`) — non-null marks the item as a PR.
- `GitHubTaskProvider.GetTasksAsync`: `.Where(i => i.PullRequest is null)` before mapping.

## Tests
`GitHubTaskProviderTests.GetTasksAsync_ExcludesPullRequests` added. 7/7 pass.

Pairs with Jezda.Platform fix for cross-repo external-task collisions.