### PR TITLE
Upgrade solution to .NET 10

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - master
-      - dev
   push:
     branches:
       - master
-      - dev
 
 permissions:
   contents: read

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
         if: ${{ github.event.inputs.skip_tests != 'true' }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Pack all projects
         run: |
-          for proj in $(find . -name 'Jezda.Common*.csproj'); do
+          for proj in $(find . -name 'Jezda.Common*.csproj' -not -name '*.Tests.csproj'); do
             echo "Packing project: $proj"
             dotnet pack "$proj" --configuration Release -p:PackageVersion=${PACKAGE_VERSION} --output ./nupkgs
           done

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: 10.x
 
       - name: Extract version from tag or input
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is **Jezda Solutions Common Libraries** - a collection of reusable .NET 10.0 libraries published as NuGet packages to support microservices architecture. The solution contains 5 packages organized as a monorepo.
+This is **Jezda Solutions Common Libraries** - a collection of reusable .NET 10.0 libraries published as NuGet packages to support microservices architecture. The solution contains 15 packages organized as a monorepo (the 5 core packages described below, plus Jezda.Common.Contracts, Jezda.Common.Files, and the Jezda.Common.Integrations.* family), along with 3 test projects.
 
 ## Project Structure
 
@@ -183,6 +183,7 @@ All projects target **.NET 10.0** with nullable reference types enabled.
 - Hangfire 1.8.21 + Hangfire.PostgreSql 1.20.12 (in Extensions)
 - FastEndpoints 7.0.1 (in Domain for query binding)
 - Npgsql 10.0.3 (in Extensions)
+- Newtonsoft.Json 13.0.4 (in Extensions — security pin; Hangfire.PostgreSql transitively pulls a vulnerable 11.0.1)
 
 ### Naming
 - Projects: `Jezda.Common.[Purpose]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,9 +205,9 @@ All projects target **.NET 10.0** with nullable reference types enabled.
 - GitHub Actions workflow extracts version from git tags (v1.0.0 format)
 
 ### Git Workflow
-- Main branch: `master`
-- Development branch: `dev`
-- When creating PRs, target the `master` branch by default
+- Single long-lived branch: `master` (the `dev` branch was retired in July 2026)
+- All work goes through feature/fix branches with PRs targeting `master`
+- Releases are cut by pushing a version tag (`v1.2.3`) to `master`, which triggers the NuGet publish workflow
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is **Jezda Solutions Common Libraries** - a collection of reusable .NET 9.0 libraries published as NuGet packages to support microservices architecture. The solution contains 5 packages organized as a monorepo.
+This is **Jezda Solutions Common Libraries** - a collection of reusable .NET 10.0 libraries published as NuGet packages to support microservices architecture. The solution contains 5 packages organized as a monorepo.
 
 ## Project Structure
 
@@ -170,7 +170,7 @@ await unitOfWork.SaveChangesAsync();
 ## Key Conventions
 
 ### Target Framework
-All projects target **.NET 9.0** with nullable reference types enabled.
+All projects target **.NET 10.0** with nullable reference types enabled.
 
 ### NuGet Package Configuration
 - All projects have `GeneratePackageOnBuild` set to true
@@ -179,10 +179,10 @@ All projects target **.NET 9.0** with nullable reference types enabled.
 - Repository URL: https://github.com/jezda-solutions/jezda-common-libs
 
 ### Dependencies
-- Entity Framework Core 9.0.8
+- Entity Framework Core 10.0.9
 - Hangfire 1.8.21 + Hangfire.PostgreSql 1.20.12 (in Extensions)
 - FastEndpoints 7.0.1 (in Domain for query binding)
-- Npgsql 9.0.3 (in Extensions)
+- Npgsql 10.0.3 (in Extensions)
 
 ### Naming
 - Projects: `Jezda.Common.[Purpose]`

--- a/Jezda.Common.Abstractions/Jezda.Common.Abstractions.csproj
+++ b/Jezda.Common.Abstractions/Jezda.Common.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jezda.Common.Abstractions</PackageId>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Abstractions/Repositories/IGenericRepository.cs
+++ b/Jezda.Common.Abstractions/Repositories/IGenericRepository.cs
@@ -381,7 +381,7 @@ public interface IGenericRepository<T> where T : class
     /// </summary>
     Task<int> UpdateWhereAsync(
         Expression<Func<T, bool>> where,
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> setters,
+        Action<UpdateSettersBuilder<T>> setters,
         CancellationToken cancellationToken = default);
 
     #endregion

--- a/Jezda.Common.Abstractions/Repositories/IGenericRepository.cs
+++ b/Jezda.Common.Abstractions/Repositories/IGenericRepository.cs
@@ -377,7 +377,8 @@ public interface IGenericRepository<T> where T : class
 
     /// <summary>
     /// Updates all entities matching the predicate in a single database operation.
-    /// Uses ExecuteUpdateAsync (EF Core 7+) for optimal performance.
+    /// Uses ExecuteUpdateAsync with the EF Core 10 <see cref="UpdateSettersBuilder{TSource}"/> API:
+    /// setters are a plain action (e.g. <c>s => s.SetProperty(x => x.IsActive, false)</c>), not an expression tree.
     /// </summary>
     Task<int> UpdateWhereAsync(
         Expression<Func<T, bool>> where,

--- a/Jezda.Common.Contracts/Jezda.Common.Contracts.csproj
+++ b/Jezda.Common.Contracts/Jezda.Common.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>1.0.33</Version>

--- a/Jezda.Common.Data.Tests/GenericRepositoryTests.cs
+++ b/Jezda.Common.Data.Tests/GenericRepositoryTests.cs
@@ -1,0 +1,148 @@
+using Jezda.Common.Data.Tests.TestInfrastructure;
+using Jezda.Common.Domain.Paged;
+using Xunit;
+
+namespace Jezda.Common.Data.Tests;
+
+public class GenericRepositoryTests : SqliteTestBase
+{
+    [Fact]
+    public async Task AddAsync_And_GetByIdAsync_Roundtrip()
+    {
+        var product = new Product { Id = Guid.NewGuid(), Name = "Widget", Price = 9.99m };
+
+        await Repository.AddAsync(product, CancellationToken.None);
+        await UnitOfWork.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+
+        var loaded = await Repository.GetByIdAsync(product.Id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal("Widget", loaded.Name);
+        Assert.Equal(9.99m, loaded.Price);
+    }
+
+    [Fact]
+    public async Task GetFirstOrDefaultAsync_TrackedEntity_SavesModificationWithoutUpdateCall()
+    {
+        var seeded = await SeedProductsAsync(("Original", 10m));
+
+        var tracked = await Repository.GetFirstOrDefaultAsync(x => x.Id == seeded[0].Id);
+        Assert.NotNull(tracked);
+
+        tracked.Name = "Renamed";
+        await UnitOfWork.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+
+        var reloaded = await Repository.GetByIdAsync(seeded[0].Id);
+        Assert.Equal("Renamed", reloaded!.Name);
+    }
+
+    [Fact]
+    public async Task GetFirstOrDefaultAsync_WithProjection_ReturnsUntrackedResult()
+    {
+        var seeded = await SeedProductsAsync(("Projected", 5m));
+
+        var name = await Repository.GetFirstOrDefaultAsync(
+            projection: x => x.Name,
+            where: x => x.Id == seeded[0].Id);
+
+        Assert.Equal("Projected", name);
+        Assert.Empty(Repository.GetTrackedEntities());
+    }
+
+    [Fact]
+    public async Task UpdateWhereAsync_Ef10SettersApi_BulkUpdatesMatchingRows()
+    {
+        await SeedProductsAsync(("Cheap A", 5m), ("Cheap B", 8m), ("Expensive", 100m));
+
+        var updated = await Repository.UpdateWhereAsync(
+            where: x => x.Price < 10m,
+            setters: s => s.SetProperty(x => x.IsActive, false)
+                           .SetProperty(x => x.Name, x => x.Name + " (sale)"));
+
+        Assert.Equal(2, updated);
+
+        var all = await Repository.GetAsNoTrackingAsync();
+        Assert.Equal(2, all.Count(x => !x.IsActive && x.Name.EndsWith("(sale)")));
+        Assert.True(all.Single(x => x.Name == "Expensive").IsActive);
+    }
+
+    [Fact]
+    public async Task DeleteWhereAsync_BulkDeletesMatchingRows()
+    {
+        await SeedProductsAsync(("Keep", 50m), ("Drop A", 1m), ("Drop B", 2m));
+
+        var deleted = await Repository.DeleteWhereAsync(x => x.Price < 10m, CancellationToken.None);
+
+        Assert.Equal(2, deleted);
+        var remaining = await Repository.GetAsNoTrackingAsync();
+        Assert.Single(remaining);
+        Assert.Equal("Keep", remaining[0].Name);
+    }
+
+    [Fact]
+    public async Task SoftDelete_SetsIsDeletedFlagAndPersists()
+    {
+        var seeded = await SeedProductsAsync(("Ghost", 1m));
+
+        var tracked = await Repository.GetFirstOrDefaultAsync(x => x.Id == seeded[0].Id);
+        Repository.SoftDelete(tracked!);
+        await UnitOfWork.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+
+        var reloaded = await Repository.GetByIdAsync(seeded[0].Id);
+        Assert.True(reloaded!.IsDeleted);
+    }
+
+    [Fact]
+    public async Task ExistsAsync_And_GetManyByIdsAsync_Work()
+    {
+        var seeded = await SeedProductsAsync(("One", 1m), ("Two", 2m), ("Three", 3m));
+
+        Assert.True(await Repository.ExistsAsync(seeded[0].Id));
+        Assert.False(await Repository.ExistsAsync(Guid.NewGuid()));
+
+        var two = await Repository.GetManyByIdsAsync([seeded[0].Id, seeded[2].Id]);
+        Assert.Equal(2, two.Count);
+    }
+
+    [Fact]
+    public async Task GetPagedItemsAsync_PagesAndSortsDescending()
+    {
+        await SeedProductsAsync(
+            ("A", 1m), ("B", 2m), ("C", 3m), ("D", 4m), ("E", 5m));
+
+        var paging = new PagingInfo
+        {
+            CurrentPage = 2,
+            PageSize = 2,
+            SortColumn = "Price",
+            SortDescending = true,
+        };
+
+        var page = await Repository.GetPagedItemsAsync(paging, defaultSortColumn: "Name");
+
+        Assert.Equal(5, page.TotalCount);
+        Assert.Equal(2, page.CurrentPage);
+        Assert.Equal(2, page.Items.Count);
+        Assert.Equal(["C", "B"], page.Items.Select(x => x.Name).ToArray());
+    }
+
+    [Fact]
+    public async Task GetPagedProjection_WithGlobalSearch_FiltersProjectedRows()
+    {
+        await SeedProductsAsync(
+            ("Red Apple", 1m), ("Green Apple", 2m), ("Banana", 3m));
+
+        var paging = new PagingInfo { CurrentPage = 1, PageSize = 10, GlobalSearch = "apple" };
+
+        var page = await Repository.GetPagedProjection(
+            paging,
+            projection: x => new { x.Name, x.Price },
+            defaultSortColumn: "Name");
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.All(page.Items, x => Assert.Contains("Apple", x.Name));
+    }
+}

--- a/Jezda.Common.Data.Tests/Jezda.Common.Data.Tests.csproj
+++ b/Jezda.Common.Data.Tests/Jezda.Common.Data.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jezda.Common.Data\Jezda.Common.Data.csproj" />
+    <ProjectReference Include="..\Jezda.Common.Domain\Jezda.Common.Domain.csproj" />
+    <ProjectReference Include="..\Jezda.Common.Extensions\Jezda.Common.Extensions.csproj" />
+    <ProjectReference Include="..\Jezda.Common.Abstractions\Jezda.Common.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jezda.Common.Data.Tests/Jezda.Common.Data.Tests.csproj
+++ b/Jezda.Common.Data.Tests/Jezda.Common.Data.Tests.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <!-- Pinned: EFCore.Sqlite pulls in vulnerable SQLitePCLRaw.lib.e_sqlite3 2.1.11 (NU1903 / GHSA-2m69-gcr7-jv3q) -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Jezda.Common.Data.Tests/PagedListExtensionsTests.cs
+++ b/Jezda.Common.Data.Tests/PagedListExtensionsTests.cs
@@ -1,0 +1,76 @@
+using Jezda.Common.Data.Tests.TestInfrastructure;
+using Jezda.Common.Domain.Paged;
+using Jezda.Common.Extensions;
+using Xunit;
+
+namespace Jezda.Common.Data.Tests;
+
+public class PagedListExtensionsTests : SqliteTestBase
+{
+    // Member-init projection (not a positional constructor) — EF can only translate
+    // sorting/filtering through the projection when properties are member-initialized.
+    private class ProductDto
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public decimal Price { get; init; }
+    }
+
+    private async Task SeedDefaultAsync() =>
+        await SeedProductsAsync(
+            ("Alpha", 30m), ("Bravo", 10m), ("Charlie", 20m), ("Delta", 40m));
+
+    [Fact]
+    public async Task ApplyPagingAndFilteringAsync_SortsByRequestedColumn()
+    {
+        await SeedDefaultAsync();
+
+        var paging = new PagingInfo { CurrentPage = 1, PageSize = 10, SortColumn = "Price" };
+
+        var result = await Context.Products
+            .Select(x => new ProductDto { Name = x.Name, Price = x.Price })
+            .ApplyPagingAndFilteringAsync(paging, defaultSortColumn: "Name");
+
+        Assert.Equal(4, result.TotalCount);
+        Assert.Equal(["Bravo", "Charlie", "Alpha", "Delta"], result.Items.Select(x => x.Name).ToArray());
+    }
+
+    [Fact]
+    public async Task ApplyPagingAndFilteringAsync_GlobalSearch_MatchesCaseInsensitive()
+    {
+        await SeedDefaultAsync();
+
+        var paging = new PagingInfo { CurrentPage = 1, PageSize = 10, GlobalSearch = "ALPHA" };
+
+        var result = await Context.Products
+            .Select(x => new ProductDto { Name = x.Name, Price = x.Price })
+            .ApplyPagingAndFilteringAsync(paging, defaultSortColumn: "Name");
+
+        Assert.Single(result.Items);
+        Assert.Equal("Alpha", result.Items[0].Name);
+    }
+
+    [Fact]
+    public async Task ApplyPagingAndFilteringAsync_SecondPage_ReturnsRemainingItems()
+    {
+        await SeedDefaultAsync();
+
+        var paging = new PagingInfo { CurrentPage = 2, PageSize = 3 };
+
+        var result = await Context.Products
+            .Select(x => new ProductDto { Name = x.Name, Price = x.Price })
+            .ApplyPagingAndFilteringAsync(paging, defaultSortColumn: "Name");
+
+        Assert.Equal(4, result.TotalCount);
+        Assert.Single(result.Items);
+        Assert.Equal("Delta", result.Items[0].Name);
+    }
+
+    [Fact]
+    public void ApplySorting_UnknownColumn_Throws()
+    {
+        var query = Context.Products.AsQueryable();
+
+        Assert.Throws<ArgumentException>(() => query.ApplySorting("Nonexistent", false));
+    }
+}

--- a/Jezda.Common.Data.Tests/TestInfrastructure/SqliteTestBase.cs
+++ b/Jezda.Common.Data.Tests/TestInfrastructure/SqliteTestBase.cs
@@ -1,0 +1,56 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jezda.Common.Data.Tests.TestInfrastructure;
+
+/// <summary>
+/// Each test class gets its own in-memory SQLite database. SQLite is a relational
+/// provider, so ExecuteUpdate/ExecuteDelete and transactions behave like production
+/// (unlike the EF InMemory provider, which does not support them).
+/// </summary>
+public abstract class SqliteTestBase : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    protected TestDbContext Context { get; }
+
+    protected ProductRepository Repository { get; }
+
+    protected TestUnitOfWork UnitOfWork { get; }
+
+    protected SqliteTestBase()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        Context = new TestDbContext(options);
+        Context.Database.EnsureCreated();
+
+        Repository = new ProductRepository(Context);
+        UnitOfWork = new TestUnitOfWork(Context);
+    }
+
+    protected async Task<List<Product>> SeedProductsAsync(params (string Name, decimal Price)[] products)
+    {
+        var entities = products
+            .Select(p => new Product { Id = Guid.NewGuid(), Name = p.Name, Price = p.Price })
+            .ToList();
+
+        Context.Products.AddRange(entities);
+        await Context.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+
+        return entities;
+    }
+
+    public void Dispose()
+    {
+        Context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Jezda.Common.Data.Tests/TestInfrastructure/TestDbContext.cs
+++ b/Jezda.Common.Data.Tests/TestInfrastructure/TestDbContext.cs
@@ -1,0 +1,31 @@
+using Jezda.Common.Domain.Entities.Base;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jezda.Common.Data.Tests.TestInfrastructure;
+
+public class Product : AuditableBaseEntity<Guid>
+{
+    public string Name { get; set; } = string.Empty;
+
+    public decimal Price { get; set; }
+
+    public bool IsActive { get; set; } = true;
+}
+
+public class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+{
+    public DbSet<Product> Products => Set<Product>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Product>(builder =>
+        {
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.Name).IsRequired();
+        });
+    }
+}
+
+public class ProductRepository(TestDbContext context) : GenericRepository<Product>(context);
+
+public class TestUnitOfWork(TestDbContext context) : UnitOfWork<TestDbContext>(context);

--- a/Jezda.Common.Data.Tests/UnitOfWorkTests.cs
+++ b/Jezda.Common.Data.Tests/UnitOfWorkTests.cs
@@ -20,11 +20,13 @@ public class UnitOfWorkTests : SqliteTestBase
     [Fact]
     public async Task Transaction_Commit_PersistsChanges()
     {
-        await using var transaction = await UnitOfWork.BeginTransactionAsync();
+        await using (await UnitOfWork.BeginTransactionAsync())
+        {
+            Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Committed", Price = 1m });
+            await UnitOfWork.SaveChangesAsync();
+            await UnitOfWork.CommitTransactionAsync();
+        }
 
-        Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Committed", Price = 1m });
-        await UnitOfWork.SaveChangesAsync();
-        await UnitOfWork.CommitTransactionAsync();
         Context.ChangeTracker.Clear();
 
         var all = await Repository.GetAsNoTrackingAsync();
@@ -35,7 +37,7 @@ public class UnitOfWorkTests : SqliteTestBase
     [Fact]
     public async Task Transaction_Rollback_DiscardsChanges()
     {
-        await using (var transaction = await UnitOfWork.BeginTransactionAsync())
+        await using (await UnitOfWork.BeginTransactionAsync())
         {
             Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Discarded", Price = 1m });
             await UnitOfWork.SaveChangesAsync();

--- a/Jezda.Common.Data.Tests/UnitOfWorkTests.cs
+++ b/Jezda.Common.Data.Tests/UnitOfWorkTests.cs
@@ -1,0 +1,60 @@
+using Jezda.Common.Data.Tests.TestInfrastructure;
+using Xunit;
+
+namespace Jezda.Common.Data.Tests;
+
+public class UnitOfWorkTests : SqliteTestBase
+{
+    [Fact]
+    public async Task HasChanges_ReflectsPendingModifications()
+    {
+        Assert.False(UnitOfWork.HasChanges());
+
+        Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Pending", Price = 1m });
+        Assert.True(UnitOfWork.HasChanges());
+
+        await UnitOfWork.SaveChangesAsync();
+        Assert.False(UnitOfWork.HasChanges());
+    }
+
+    [Fact]
+    public async Task Transaction_Commit_PersistsChanges()
+    {
+        await using var transaction = await UnitOfWork.BeginTransactionAsync();
+
+        Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Committed", Price = 1m });
+        await UnitOfWork.SaveChangesAsync();
+        await UnitOfWork.CommitTransactionAsync();
+        Context.ChangeTracker.Clear();
+
+        var all = await Repository.GetAsNoTrackingAsync();
+        Assert.Single(all);
+        Assert.Equal("Committed", all[0].Name);
+    }
+
+    [Fact]
+    public async Task Transaction_Rollback_DiscardsChanges()
+    {
+        await using (var transaction = await UnitOfWork.BeginTransactionAsync())
+        {
+            Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Discarded", Price = 1m });
+            await UnitOfWork.SaveChangesAsync();
+            await UnitOfWork.RollbackTransactionAsync();
+        }
+
+        Context.ChangeTracker.Clear();
+        var all = await Repository.GetAsNoTrackingAsync();
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task DetachAllEntities_ClearsTracking()
+    {
+        Context.Products.Add(new Product { Id = Guid.NewGuid(), Name = "Tracked", Price = 1m });
+        await UnitOfWork.SaveChangesAsync();
+
+        Assert.NotEmpty(Repository.GetTrackedEntities());
+        UnitOfWork.DetachAllEntities();
+        Assert.Empty(Repository.GetTrackedEntities());
+    }
+}

--- a/Jezda.Common.Data/GenericRepository.cs
+++ b/Jezda.Common.Data/GenericRepository.cs
@@ -1103,10 +1103,10 @@ public abstract class GenericRepository<T>(DbContext context) : IGenericReposito
 
     /// <summary>
     /// Updates all entities matching the predicate in a single database operation.
-    /// Uses ExecuteUpdateAsync (EF Core 7+) for optimal performance.
+    /// Uses ExecuteUpdateAsync with the EF Core 10 <see cref="UpdateSettersBuilder{TSource}"/> API.
     /// </summary>
     /// <param name="where">The filter predicate</param>
-    /// <param name="setters">The property setters expression</param>
+    /// <param name="setters">The property setters action (plain lambda, not an expression tree)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The number of entities updated</returns>
     /// <remarks>

--- a/Jezda.Common.Data/GenericRepository.cs
+++ b/Jezda.Common.Data/GenericRepository.cs
@@ -1132,7 +1132,7 @@ public abstract class GenericRepository<T>(DbContext context) : IGenericReposito
     /// </remarks>
     public virtual async Task<int> UpdateWhereAsync(
         Expression<Func<T, bool>> where,
-        Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>> setters,
+        Action<UpdateSettersBuilder<T>> setters,
         CancellationToken cancellationToken = default)
     {
         return await _dbSet.Where(where).ExecuteUpdateAsync(setters, cancellationToken);

--- a/Jezda.Common.Data/Jezda.Common.Data.csproj
+++ b/Jezda.Common.Data/Jezda.Common.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jezda.Common.Data</PackageId>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Domain/Jezda.Common.Domain.csproj
+++ b/Jezda.Common.Domain/Jezda.Common.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageId>Jezda.Common.Domain</PackageId>

--- a/Jezda.Common.Extensions/Jezda.Common.Extensions.csproj
+++ b/Jezda.Common.Extensions/Jezda.Common.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jezda.Common.Extensions</PackageId>
@@ -25,8 +25,10 @@
   <ItemGroup>
     <PackageReference Include="Hangfire" Version="1.8.21" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-    <PackageReference Include="Npgsql" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <!-- Pinned: Hangfire.PostgreSql pulls in vulnerable Newtonsoft.Json 11.0.1 (NU1903 / GHSA-5crp-9r3c-p9vr) -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Files.Tests/Jezda.Common.Files.Tests.csproj
+++ b/Jezda.Common.Files.Tests/Jezda.Common.Files.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />

--- a/Jezda.Common.Files/Jezda.Common.Files.csproj
+++ b/Jezda.Common.Files/Jezda.Common.Files.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jezda.Common.Files</PackageId>

--- a/Jezda.Common.Helpers/Jezda.Common.Helpers.csproj
+++ b/Jezda.Common.Helpers/Jezda.Common.Helpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Jezda.Common.Helpers</PackageId>
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.Abstractions/Jezda.Common.Integrations.Abstractions.csproj
+++ b/Jezda.Common.Integrations.Abstractions/Jezda.Common.Integrations.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.AzureDevOps/Jezda.Common.Integrations.AzureDevOps.csproj
+++ b/Jezda.Common.Integrations.AzureDevOps/Jezda.Common.Integrations.AzureDevOps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.ClickUp/Jezda.Common.Integrations.ClickUp.csproj
+++ b/Jezda.Common.Integrations.ClickUp/Jezda.Common.Integrations.ClickUp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.GitHub/Jezda.Common.Integrations.GitHub.csproj
+++ b/Jezda.Common.Integrations.GitHub/Jezda.Common.Integrations.GitHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.Jira/Jezda.Common.Integrations.Jira.csproj
+++ b/Jezda.Common.Integrations.Jira/Jezda.Common.Integrations.Jira.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.Monday/Jezda.Common.Integrations.Monday.csproj
+++ b/Jezda.Common.Integrations.Monday/Jezda.Common.Integrations.Monday.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.Tests/Jezda.Common.Integrations.Tests.csproj
+++ b/Jezda.Common.Integrations.Tests/Jezda.Common.Integrations.Tests.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations.Trello/Jezda.Common.Integrations.Trello.csproj
+++ b/Jezda.Common.Integrations.Trello/Jezda.Common.Integrations.Trello.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Common.Integrations/Jezda.Common.Integrations.csproj
+++ b/Jezda.Common.Integrations/Jezda.Common.Integrations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jezda.Solutions.CommonLibs.sln
+++ b/Jezda.Solutions.CommonLibs.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jezda.Common.Integrations.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jezda.Common.Integrations.Monday", "Jezda.Common.Integrations.Monday\Jezda.Common.Integrations.Monday.csproj", "{79FF7152-415C-4B4B-BEB7-F267F2C0EC11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jezda.Common.Data.Tests", "Jezda.Common.Data.Tests\Jezda.Common.Data.Tests.csproj", "{31569ABF-755F-4508-908E-0A541E57E50B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,18 @@ Global
 		{79FF7152-415C-4B4B-BEB7-F267F2C0EC11}.Release|x64.Build.0 = Release|Any CPU
 		{79FF7152-415C-4B4B-BEB7-F267F2C0EC11}.Release|x86.ActiveCfg = Release|Any CPU
 		{79FF7152-415C-4B4B-BEB7-F267F2C0EC11}.Release|x86.Build.0 = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|x64.Build.0 = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Debug|x86.Build.0 = Debug|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|x64.ActiveCfg = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|x64.Build.0 = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|x86.ActiveCfg = Release|Any CPU
+		{31569ABF-755F-4508-908E-0A541E57E50B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A comprehensive collection of reusable .NET libraries providing common functionality for enterprise applications, including repository patterns, data access abstractions, domain models, extensions, and helpers.
 
 [![Build & Test](https://github.com/jezda-solutions/jezda-common-libs/actions/workflows/pr-validation.yml/badge.svg)](https://github.com/jezda-solutions/jezda-common-libs/actions/workflows/pr-validation.yml)
-[![.NET](https://img.shields.io/badge/.NET-9.0-blue.svg)](https://dotnet.microsoft.com/download)
-[![Entity Framework Core](https://img.shields.io/badge/EF%20Core-9.0.8-blue.svg)](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/)
+[![.NET](https://img.shields.io/badge/.NET-10.0-blue.svg)](https://dotnet.microsoft.com/download)
+[![Entity Framework Core](https://img.shields.io/badge/EF%20Core-10.0.9-blue.svg)](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 ## 📦 NuGet Packages

--- a/docs/plans/central-package-management.md
+++ b/docs/plans/central-package-management.md
@@ -1,0 +1,37 @@
+# Central Package Management + Build Hygiene
+
+**Status:** Pending
+**Origin:** Code-review findings from PR #138 (.NET 10 upgrade) — valid, but out of scope there.
+
+## Problem
+
+1. **Package versions are copy-pasted across 18 csproj files.** The .NET 10 upgrade had to
+   hand-edit ~60 version lines; Microsoft.Extensions.Logging.Abstractions appears in 8 files,
+   DI.Abstractions in 6, EF Core in 3, the xunit/Test.Sdk block in 3. One missed file leaves
+   mixed versions that restore silently unifies (or NU1605-downgrades) in consumers.
+2. **TargetFramework is declared per-csproj (18 times)** instead of once.
+3. **Security pins live in single csproj files** (Newtonsoft.Json in Extensions,
+   SQLitePCLRaw in Data.Tests) — a sibling project adding the same transitive source
+   would silently reintroduce the vulnerable version.
+4. **publish-nuget.yml redundancy:** `GeneratePackageOnBuild=true` in every library csproj
+   means the build step already packs everything at the stale csproj version, then the pack
+   loop re-packs at the tag version; the pack loop also rebuilds per-project (no `--no-build`).
+5. **xunit 2.9.2 is paired with xunit.runner.visualstudio 2.8.2** in all three test projects.
+
+## Suggested fix
+
+- Introduce `Directory.Build.props` (TargetFramework, Nullable, ImplicitUsings, shared package
+  metadata) and `Directory.Packages.props` with `ManagePackageVersionsCentrally` +
+  `CentralPackageTransitivePinningEnabled` (moves the security pins repo-wide).
+  The `dotnet-nuget:convert-to-cpm` skill automates this conversion with build validation.
+- Drop `GeneratePackageOnBuild` from csprojs; let the publish workflow's pack loop (with
+  `--no-build`) be the only pack step.
+- Align xunit runner version with xunit core in one central place.
+
+## Also worth validating (runtime, not build)
+
+- **Hangfire.PostgreSql 1.20.12 + Npgsql 10.0.3 pairing** — Hangfire.PostgreSql declares
+  Npgsql >= 6.0.11 and now resolves to a 4-majors-newer assembly. The Hangfire storage path
+  (`HangfireExtensions`) has no test coverage in this repo (tests are SQLite-based).
+  Smoke-test job storage init + polling against PostgreSQL in a consumer before relying on
+  scheduled jobs in production, or add a PostgreSQL-backed integration test (Testcontainers).

--- a/docs/plans/done/2026-07-05-net10-upgrade.md
+++ b/docs/plans/done/2026-07-05-net10-upgrade.md
@@ -1,6 +1,6 @@
 # .NET 10 Upgrade
 
-**Status:** In Progress
+**Status:** Done (PR #138)
 **Date:** 2026-07-05
 
 ## Goal

--- a/docs/plans/in-progress/2026-07-05-net10-upgrade.md
+++ b/docs/plans/in-progress/2026-07-05-net10-upgrade.md
@@ -29,9 +29,12 @@ downgrade from PR #124 and moves the whole solution (17 projects) to net10.0.
 ## Verification
 
 - `dotnet build --configuration Release` clean
-- `dotnet test` green (Files.Tests, Integrations.Tests)
+- `dotnet test` green (Files.Tests, Integrations.Tests, Data.Tests — new suite guarding
+  EF Core 10 behavior: repository CRUD/tracking, UpdateWhereAsync setters API, bulk
+  delete, paging/sorting/global search, UnitOfWork transactions)
 
 ## Rollout
 
-PR → `dev`, then dev → master promotion per team flow. Consumers (nexus, hrms, commerce,
-tms, golub) need their own net10 upgrade before taking new package versions.
+PR → `master` (the `dev` branch is retired as part of this work; releases are cut by
+tagging `master`). Consumers (jezda-platform modules, golub) need their own net10
+upgrade before taking new package versions.

--- a/docs/plans/in-progress/2026-07-05-net10-upgrade.md
+++ b/docs/plans/in-progress/2026-07-05-net10-upgrade.md
@@ -33,5 +33,5 @@ downgrade from PR #124 and moves the whole solution (17 projects) to net10.0.
 
 ## Rollout
 
-PR → `dev`, then dev → master promotion per team flow. Consumers (nexus, hrms, piazza,
+PR → `dev`, then dev → master promotion per team flow. Consumers (nexus, hrms, commerce,
 tms, golub) need their own net10 upgrade before taking new package versions.

--- a/docs/plans/in-progress/2026-07-05-net10-upgrade.md
+++ b/docs/plans/in-progress/2026-07-05-net10-upgrade.md
@@ -1,0 +1,37 @@
+# .NET 10 Upgrade
+
+**Status:** In Progress
+**Date:** 2026-07-05
+
+## Goal
+
+Upgrade all common-libs packages from .NET 9 to .NET 10. This reverses the temporary
+downgrade from PR #124 and moves the whole solution (17 projects) to net10.0.
+
+## Scope
+
+- [x] All 17 `.csproj` files: `<TargetFramework>net9.0</TargetFramework>` → `net10.0`
+- [x] Microsoft.* packages 9.0.9 → 10.0.9 (EF Core, Extensions.*, Identity.Core)
+- [x] Npgsql 9.0.4 → 10.0.3
+- [x] Microsoft.Extensions.Http.Resilience 9.1.0 → 10.7.0
+- [x] Microsoft.NET.Test.Sdk 17.11.1 → 18.7.0
+- [x] CI workflows (`pr-validation.yml`, `publish-nuget.yml`): `dotnet-version: 9.x` → `10.x`
+- [x] CLAUDE.md: update framework/dependency references
+
+## Deliberately NOT changed
+
+- **FastEndpoints 7.0.1** — bump to 8.x is a breaking change for consumers; net9 assembly
+  runs fine on net10.
+- **Hangfire 1.8.21 / Hangfire.PostgreSql** — netstandard targets, compatible as-is.
+- **xunit 2.9.2 / coverlet** — compatible, no need to churn.
+- **Microsoft.AspNetCore.Http.Abstractions 2.3.0** — legacy compat package, unchanged.
+
+## Verification
+
+- `dotnet build --configuration Release` clean
+- `dotnet test` green (Files.Tests, Integrations.Tests)
+
+## Rollout
+
+PR → `dev`, then dev → master promotion per team flow. Consumers (nexus, hrms, piazza,
+tms, golub) need their own net10 upgrade before taking new package versions.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

Moves the whole solution (17 projects) from **net9.0 to net10.0**, reversing the temporary downgrade from #124.

### Changes
- All `.csproj` files retargeted `net9.0` → `net10.0`
- **Microsoft.\* / EF Core** packages `9.0.9` → `10.0.9` (EntityFrameworkCore, Extensions.*, Identity.Core)
- **Npgsql** `9.0.4` → `10.0.3`
- **Microsoft.Extensions.Http.Resilience** `9.1.0` → `10.7.0`
- **Microsoft.NET.Test.Sdk** `17.11.1` → `18.7.0`
- CI workflows (`pr-validation.yml`, `publish-nuget.yml`): `dotnet-version: 9.x` → `10.x`

### API change (breaking for consumers)
EF Core 10 removed `SetPropertyCalls<T>` — `ExecuteUpdate` setters are now a plain `Action<UpdateSettersBuilder<T>>`. `IGenericRepository<T>.UpdateWhereAsync` / `GenericRepository<T>.UpdateWhereAsync` signatures updated accordingly. Call sites using the fluent `s => s.SetProperty(...)` lambda syntax compile unchanged; only explicit `Expression<Func<SetPropertyCalls<T>, ...>>` variable declarations need updating.

### Security
Pinned **Newtonsoft.Json 13.0.4** in Extensions — Hangfire.PostgreSql transitively pulled vulnerable 11.0.1 (NU1903, GHSA-5crp-9r3c-p9vr). Build is now warning-free.

### Deliberately NOT bumped
- FastEndpoints 7.0.1 (8.x is a breaking change for consumers; net9 assembly runs fine on net10)
- Hangfire 1.8.21 / Hangfire.PostgreSql 1.20.12 (netstandard, compatible)
- xunit 2.9.2, coverlet, Microsoft.AspNetCore.Http.Abstractions 2.3.0

### Rollout note
Consumers (jezda-platform modules, golub) must upgrade to net10 before taking the next package version.

## Test plan
- [x] `dotnet build --configuration Release` — 0 errors, 0 warnings
- [x] `dotnet test` — 73/73 passed (Files.Tests 8, Data.Tests 17 — new suite guarding EF Core 10 behavior, Integrations.Tests 48) on net10.0
- [ ] PR validation workflow green on `dotnet-version: 10.x`
- [ ] Verify pack + publish on next version tag

