### PR TITLE
Switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -77,5 +77,5 @@ jobs:
       - name: Push packages to NuGet.org
         run: |
           for pkg in ./nupkgs/*.nupkg; do
-            dotnet nuget push "$pkg" --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$pkg" --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           done

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,6 +21,10 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write  # OIDC token issuance for NuGet Trusted Publishing
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -62,8 +66,16 @@ jobs:
       - name: List generated packages
         run: ls -la ./nupkgs/
 
+      # Trusted Publishing: exchange the GitHub OIDC token for a short-lived (1h) NuGet API key.
+      # Requires a Trusted Publishing policy on nuget.org for this repo + workflow file.
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push packages to NuGet.org
         run: |
           for pkg in ./nupkgs/*.nupkg; do
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$pkg" --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ dotnet pack Jezda.Common.Abstractions/Jezda.Common.Abstractions.csproj --configu
 GitHub Actions workflow (`.github/workflows/publish-nuget.yml`) handles automated publishing:
 - Triggered by version tags (e.g., `v1.0.0`) or manual workflow dispatch
 - Builds all projects, packs them, and publishes to NuGet.org
-- Uses `NUGET_API_KEY` secret
+- Authenticates via [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) (OIDC): `NuGet/login@v1` exchanges the GitHub OIDC token for a short-lived API key — no long-lived key secret. Requires the Trusted Publishing policy on nuget.org (repo `jezda-solutions/common-libs`, workflow `publish-nuget.yml`) and the `NUGET_USER` secret (nuget.org profile name)
 
-Manual publishing using the PowerShell script:
-```powershell
-./push-nuget-packages.ps1
+Manual/re-run publishing goes through the same workflow (no local API keys):
+```bash
+gh workflow run publish-nuget.yml -f version=1.2.3
 ```
 
 ## Architecture Patterns

--- a/README.md
+++ b/README.md
@@ -520,8 +520,14 @@ dotnet pack --configuration Release
 
 ### Publish to NuGet
 
+Publishing runs exclusively through GitHub Actions using [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) (OIDC, no long-lived API keys):
+
 ```bash
-dotnet nuget push ./Jezda.Common.Data/bin/Release/Jezda.Common.Data.1.0.0.nupkg --source https://api.nuget.org/v3/index.json --api-key YOUR_API_KEY
+# Release: tag master and push the tag
+git tag v1.2.3 && git push origin v1.2.3
+
+# Or re-run/publish manually for a specific version
+gh workflow run publish-nuget.yml -f version=1.2.3
 ```
 
 ## 📖 Additional Documentation


### PR DESCRIPTION
## Summary

The v1.1.0 publish run failed with 403 — the long-lived `NUGET_API_KEY` secret is expired/invalid. Instead of rotating it, this switches the publish workflow to [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): the job requests a GitHub OIDC token (`id-token: write`) and `NuGet/login@v1` exchanges it for a short-lived (1h) API key right before push. No more long-lived secrets to rotate.

### Required one-time setup (outside this PR)
1. On nuget.org: **Trusted Publishing** → add policy: Repository Owner `jezda-solutions`, Repository `common-libs`, Workflow File `publish-nuget.yml` (file name only), Environment: empty. Note: policy may start as "temporarily active (7 days)" until the first successful publish locks it.
2. In the repo: set `NUGET_USER` secret to the nuget.org profile name (not email): `gh secret set NUGET_USER`.
3. The stale `NUGET_API_KEY` secret can then be deleted.

### Publishing v1.1.0 after merge
Tag `v1.1.0` already exists (nothing was published — the very first push got the 403). After merge, run the workflow manually with the existing version input:
```
gh workflow run publish-nuget.yml -f version=1.1.0 -f skip_tests=false
```

## Test plan
- [x] YAML change reviewed against the official Trusted Publishing doc example
- [ ] Manual dispatch publishes all 15 packages as 1.1.0