### PR TITLE
Remove stale nuget.config note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,4 +215,3 @@ All projects target **.NET 10.0** with nullable reference types enabled.
 - This is a shared library repository - avoid adding application-specific logic
 - All code should be generic and reusable across multiple microservices
 - Consider backward compatibility when modifying existing public APIs
-- The `nuget.config` file contains GitHub Packages feed configuration (note: contains credentials - should be gitignored in production)


### PR DESCRIPTION
The local `nuget.config` / `push-nuget-packages.ps1` (GitHub Packages flow with a plaintext PAT) were deleted after switching to NuGet Trusted Publishing in #139 — this drops the CLAUDE.md note describing the removed file.

## Test plan
- [x] Docs-only change; `grep nuget.config CLAUDE.md` returns nothing