### PR TITLE
feat(integrations): SearchTasksAsync — query providers directly instead of caching every task

### DIFF
--- a/Jezda.Common.Integrations.Abstractions/IExternalTaskProvider.cs
+++ b/Jezda.Common.Integrations.Abstractions/IExternalTaskProvider.cs
@@ -22,4 +22,82 @@ public interface IExternalTaskProvider
         string projectId,
         string? baseUrl = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds tasks matching <paramref name="searchTerm"/> without enumerating every project.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists for interactive lookups — a user typing into a task picker — where
+    /// <see cref="GetProjectsAsync"/> followed by <see cref="GetTasksAsync"/> per project is one
+    /// round trip per project and far too slow to sit behind a keystroke.
+    /// </para>
+    /// <para>
+    /// <b>The default implementation is that slow fan-out.</b> It is correct for every provider and
+    /// keeps implementors that have nothing better compiling and working, but it costs
+    /// <c>1 + N</c> requests and filters in memory. Any provider whose API can search server-side
+    /// should override it; <c>GitHubTaskProvider</c> and <c>AzureDevOpsTaskProvider</c> do.
+    /// </para>
+    /// <para>
+    /// Matching is case-insensitive on <see cref="ExternalTaskDto.Title"/> and
+    /// <see cref="ExternalTaskDto.Id"/>. An override may match more (labels, description, assignee)
+    /// but must not match less, or the picker will behave differently per provider.
+    /// </para>
+    /// </remarks>
+    /// <param name="searchTerm">
+    /// The user's text. Callers are expected to have trimmed it and rejected the empty case; an
+    /// implementation given whitespace returns an empty list rather than every task in the account.
+    /// </param>
+    /// <param name="limit">Maximum number of results to return. Implementations may return fewer.</param>
+    Task<IReadOnlyList<ExternalTaskDto>> SearchTasksAsync(
+        string accessToken,
+        string searchTerm,
+        int limit = 20,
+        string? baseUrl = null,
+        CancellationToken cancellationToken = default)
+        => SearchByFanOutAsync(this, accessToken, searchTerm, limit, baseUrl, cancellationToken);
+
+    /// <summary>
+    /// The fallback search: list every project, list every task in each, filter in memory.
+    /// </summary>
+    /// <remarks>
+    /// A static helper rather than inline in the default body so an override can still reach it —
+    /// a provider whose native search covers only part of its surface can fall back to this for the
+    /// rest without reimplementing it.
+    /// </remarks>
+    static async Task<IReadOnlyList<ExternalTaskDto>> SearchByFanOutAsync(
+        IExternalTaskProvider provider,
+        string accessToken,
+        string searchTerm,
+        int limit,
+        string? baseUrl,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm) || limit <= 0)
+        {
+            return [];
+        }
+
+        var term = searchTerm.Trim();
+        var projects = await provider.GetProjectsAsync(accessToken, baseUrl, cancellationToken);
+        var matches = new List<ExternalTaskDto>();
+
+        foreach (var project in projects)
+        {
+            // Stop calling the provider once we have enough: the caller asked for `limit` results,
+            // and each extra project is another HTTP round trip nobody is waiting for.
+            if (matches.Count >= limit)
+            {
+                break;
+            }
+
+            var tasks = await provider.GetTasksAsync(accessToken, project.Id, baseUrl, cancellationToken);
+
+            matches.AddRange(tasks.Where(t =>
+                t.Title.Contains(term, StringComparison.OrdinalIgnoreCase)
+                || t.Id.Contains(term, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return matches.Count > limit ? matches[..limit] : matches;
+    }
 }

--- a/Jezda.Common.Integrations.Abstractions/IExternalTaskProvider.cs
+++ b/Jezda.Common.Integrations.Abstractions/IExternalTaskProvider.cs
@@ -33,15 +33,25 @@ public interface IExternalTaskProvider
     /// round trip per project and far too slow to sit behind a keystroke.
     /// </para>
     /// <para>
-    /// <b>The default implementation is that slow fan-out.</b> It is correct for every provider and
-    /// keeps implementors that have nothing better compiling and working, but it costs
-    /// <c>1 + N</c> requests and filters in memory. Any provider whose API can search server-side
-    /// should override it; <c>GitHubTaskProvider</c> and <c>AzureDevOpsTaskProvider</c> do.
+    /// <b>The default implementation is that slow fan-out.</b> It keeps implementors that have
+    /// nothing better compiling and working, but it costs <c>1 + N</c> requests and filters in
+    /// memory. Any provider whose API can search server-side should override it;
+    /// <c>GitHubTaskProvider</c> and <c>AzureDevOpsTaskProvider</c> do.
     /// </para>
     /// <para>
-    /// Matching is case-insensitive on <see cref="ExternalTaskDto.Title"/> and
-    /// <see cref="ExternalTaskDto.Id"/>. An override may match more (labels, description, assignee)
-    /// but must not match less, or the picker will behave differently per provider.
+    /// <b>The fallback is best-effort, not exhaustive.</b> It can only see what
+    /// <see cref="GetTasksAsync"/> returns, and several providers return a truncated first page
+    /// there — Jira caps at 50 issues per project with no <c>startAt</c> loop, ClickUp and Monday
+    /// take their API defaults. A task past that cut is simply not found, and the caller cannot
+    /// tell that apart from "no such task". Overriding with a native search is the fix; paging
+    /// <see cref="GetTasksAsync"/> is the other.
+    /// </para>
+    /// <para>
+    /// Matching in the fallback is case-insensitive on <see cref="ExternalTaskDto.Title"/> and
+    /// <see cref="ExternalTaskDto.Id"/>. An override may match more (labels, description,
+    /// assignee), and may match less where the provider's API leaves no choice — GitHub scopes to
+    /// <c>involves:@me</c>, Azure DevOps matches title only. A narrower scope must be documented on
+    /// the override, because the picker then behaves differently per provider.
     /// </para>
     /// </remarks>
     /// <param name="searchTerm">

--- a/Jezda.Common.Integrations.AzureDevOps/Models/AdoModels.cs
+++ b/Jezda.Common.Integrations.AzureDevOps/Models/AdoModels.cs
@@ -13,16 +13,20 @@ public sealed class AdoWorkItem
     [JsonPropertyName("fields")]
     public Dictionary<string, object> Fields { get; set; } = new();
 
-    // Helper property to safely get title
-    public string Title => Fields.TryGetValue("System.Title", out var title) ? title?.ToString() ?? string.Empty : string.Empty;
+    public string Title => Field("System.Title");
 
-    // Helper property to safely get state
-    public string State => Fields.TryGetValue("System.State", out var state) ? state?.ToString() ?? string.Empty : string.Empty;
+    public string State => Field("System.State");
 
     // The owning team project. Needed when the query was not scoped to one project — an
     // organisation-wide WIQL search returns work items from many, and the project cannot be
     // inferred from the request. `_apis/wit/workitems?ids=` returns this field by default.
-    public string TeamProject => Fields.TryGetValue("System.TeamProject", out var project) ? project?.ToString() ?? string.Empty : string.Empty;
+    public string TeamProject => Field("System.TeamProject");
+
+    // Azure DevOps returns work item fields as an untyped bag, and which keys are present depends
+    // on the process template and on whether the request narrowed `fields`. Every read is
+    // therefore "absent and null both mean empty".
+    private string Field(string name) =>
+        Fields.TryGetValue(name, out var value) ? value?.ToString() ?? string.Empty : string.Empty;
 }
 
 public sealed class AdoWiqlRequest

--- a/Jezda.Common.Integrations.AzureDevOps/Models/AdoModels.cs
+++ b/Jezda.Common.Integrations.AzureDevOps/Models/AdoModels.cs
@@ -18,6 +18,11 @@ public sealed class AdoWorkItem
 
     // Helper property to safely get state
     public string State => Fields.TryGetValue("System.State", out var state) ? state?.ToString() ?? string.Empty : string.Empty;
+
+    // The owning team project. Needed when the query was not scoped to one project — an
+    // organisation-wide WIQL search returns work items from many, and the project cannot be
+    // inferred from the request. `_apis/wit/workitems?ids=` returns this field by default.
+    public string TeamProject => Fields.TryGetValue("System.TeamProject", out var project) ? project?.ToString() ?? string.Empty : string.Empty;
 }
 
 public sealed class AdoWiqlRequest

--- a/Jezda.Common.Integrations.AzureDevOps/Providers/AzureDevOpsTaskProvider.cs
+++ b/Jezda.Common.Integrations.AzureDevOps/Providers/AzureDevOpsTaskProvider.cs
@@ -76,47 +76,23 @@ public sealed class AzureDevOpsTaskProvider(
         using var client = CreateClient(accessToken, baseUrl);
 
         // Execute WIQL query to get work item IDs
-        var sanitizedProjectId = projectId.Replace("'", "''");
         var wiqlRequest = new AdoWiqlRequest
         {
-            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{sanitizedProjectId}' AND [System.State] <> 'Removed' ORDER BY [System.Id] DESC"
+            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{EscapeWiql(projectId)}' AND [System.State] <> 'Removed' ORDER BY [System.Id] DESC"
         };
 
-        var wiqlResponse = await client.PostAsJsonAsync(
-            $"{Uri.EscapeDataString(projectId)}/_apis/wit/wiql?api-version={_apiVersion}", wiqlRequest, JsonOptions, cancellationToken);
-        wiqlResponse.EnsureSuccessStatusCode();
+        var references = await RunWiqlAsync(
+            client, wiqlRequest, $"{Uri.EscapeDataString(projectId)}/_apis/wit/wiql", cancellationToken);
 
-        var wiqlResult = await wiqlResponse.Content.ReadFromJsonAsync<AdoWiqlResponse>(JsonOptions, cancellationToken);
-
-        if (wiqlResult?.WorkItems is not { Count: > 0 })
+        if (references.Count == 0)
         {
             return [];
         }
 
-        // Batch fetch work item details
-        var allWorkItems = new List<AdoWorkItem>();
+        var workItems = await FetchWorkItemDetailsAsync(
+            client, references.Select(wi => wi.Id), cancellationToken);
 
-        foreach (var batch in wiqlResult.WorkItems.Chunk(200))
-        {
-            var idsString = string.Join(",", batch.Select(wi => wi.Id));
-            var detailsUrl = $"_apis/wit/workitems?ids={idsString}&api-version={_apiVersion}";
-            var detailsResponse = await client.GetFromJsonAsync<AdoWorkItemListResponse>(detailsUrl, JsonOptions, cancellationToken);
-
-            if (detailsResponse?.Value != null)
-            {
-                allWorkItems.AddRange(detailsResponse.Value);
-            }
-        }
-
-        return [.. allWorkItems.Select(wi => new ExternalTaskDto
-        {
-            Id = wi.Id.ToString(),
-            Title = wi.Title,
-            Status = wi.State,
-            Url = wi.Url,
-            ProjectId = projectId,
-            Provider = ExternalProvider.AzureDevOps
-        })];
+        return [.. workItems.Select(wi => ToExternalTask(wi, projectId))];
     }
 
     /// <summary>
@@ -135,7 +111,9 @@ public sealed class AzureDevOpsTaskProvider(
     /// <c>CONTAINS</c> is a substring match on the title only, and is what Azure DevOps can index;
     /// <c>CONTAINS WORDS</c> would be full-text but requires the search extension to be installed.
     /// Results come back newest-changed first, which is the useful order for someone looking for
-    /// what they were working on.
+    /// what they were working on. <c>TOP</c> applies that ordering server-side, so the rows the
+    /// caller keeps are chosen by Azure DevOps rather than by trimming an unbounded id list here —
+    /// a common term against a large organisation otherwise returns thousands of refs to discard.
     /// </para>
     /// </remarks>
     public async Task<IReadOnlyList<ExternalTaskDto>> SearchTasksAsync(
@@ -154,43 +132,115 @@ public sealed class AzureDevOpsTaskProvider(
 
         using var client = CreateClient(accessToken, baseUrl);
 
-        // Same escaping as GetTasksAsync: WIQL string literals are single-quoted, and a quote in
-        // the user's text would otherwise end the literal.
-        var sanitizedTerm = searchTerm.Trim().Replace("'", "''");
         var wiqlRequest = new AdoWiqlRequest
         {
-            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.Title] CONTAINS '{sanitizedTerm}' AND [System.State] <> 'Removed' ORDER BY [System.ChangedDate] DESC"
+            Query = $"SELECT TOP {limit} [System.Id] FROM WorkItems WHERE [System.Title] CONTAINS '{EscapeWiql(searchTerm.Trim())}' AND [System.State] <> 'Removed' ORDER BY [System.ChangedDate] DESC"
         };
 
-        var wiqlResponse = await client.PostAsJsonAsync(
-            $"_apis/wit/wiql?api-version={_apiVersion}", wiqlRequest, JsonOptions, cancellationToken);
-        wiqlResponse.EnsureSuccessStatusCode();
+        // No project segment in the path: that is what makes this organisation-wide.
+        var references = await RunWiqlAsync(client, wiqlRequest, "_apis/wit/wiql", cancellationToken);
 
-        var wiqlResult = await wiqlResponse.Content.ReadFromJsonAsync<AdoWiqlResponse>(JsonOptions, cancellationToken);
-
-        if (wiqlResult?.WorkItems is not { Count: > 0 })
+        if (references.Count == 0)
         {
             return [];
         }
 
-        // Trim to `limit` before fetching details: WIQL returns ids only, so the expensive call is
-        // the one below and there is no reason to hydrate rows the caller will discard.
-        var ids = wiqlResult.WorkItems.Take(limit).Select(wi => wi.Id);
-        var idsString = string.Join(",", ids);
+        // TOP already bounded the query, but a server that ignores it must not turn into an
+        // unbounded details batch.
+        var ids = references.Take(limit).Select(wi => wi.Id).ToList();
+        var workItems = await FetchWorkItemDetailsAsync(client, ids, cancellationToken);
 
-        var detailsResponse = await client.GetFromJsonAsync<AdoWorkItemListResponse>(
-            $"_apis/wit/workitems?ids={idsString}&api-version={_apiVersion}", JsonOptions, cancellationToken);
+        // The details batch does not contract to return items in the order the ids were supplied,
+        // and the WIQL's ORDER BY is the whole reason the newest-changed item should be first.
+        // Re-key on the requested order; the lookup also drops anything deleted between the calls.
+        var byId = workItems.ToDictionary(wi => wi.Id);
 
-        return [.. (detailsResponse?.Value ?? []).Select(wi => new ExternalTaskDto
-        {
-            Id = wi.Id.ToString(),
-            Title = wi.Title,
-            Status = wi.State,
-            Url = wi.Url,
-            ProjectId = wi.TeamProject,
-            Provider = ExternalProvider.AzureDevOps
-        })];
+        return
+        [
+            .. ids.Where(byId.ContainsKey)
+                  .Select(id => ToExternalTask(byId[id], byId[id].TeamProject))
+        ];
     }
+
+    /// <summary>
+    /// Escapes a value for interpolation into a WIQL string literal.
+    /// </summary>
+    /// <remarks>
+    /// WIQL string literals are single-quoted, so an apostrophe in user text — a project named
+    /// "Bob's team", a search for "it's broken" — would otherwise close the literal early and
+    /// change the query's meaning.
+    /// </remarks>
+    private static string EscapeWiql(string value) => value.Replace("'", "''");
+
+    /// <summary>
+    /// Posts a WIQL query and returns the work item references it matched.
+    /// </summary>
+    /// <param name="path">
+    /// The WIQL endpoint without its query string. Project-scoped for <see cref="GetTasksAsync"/>,
+    /// organisation-wide for <see cref="SearchTasksAsync"/> — the only difference between them.
+    /// </param>
+    private async Task<IReadOnlyList<AdoWorkItemReference>> RunWiqlAsync(
+        HttpClient client,
+        AdoWiqlRequest wiqlRequest,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        var response = await client.PostAsJsonAsync(
+            $"{path}?api-version={_apiVersion}", wiqlRequest, JsonOptions, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<AdoWiqlResponse>(JsonOptions, cancellationToken);
+
+        return result?.WorkItems ?? [];
+    }
+
+    /// <summary>
+    /// Hydrates work item ids into full work items.
+    /// </summary>
+    /// <remarks>
+    /// Chunked at 200 because that is the maximum number of ids Azure DevOps accepts on a single
+    /// <c>workitems?ids=</c> request; beyond it the call fails outright rather than truncating.
+    /// </remarks>
+    private async Task<List<AdoWorkItem>> FetchWorkItemDetailsAsync(
+        HttpClient client,
+        IEnumerable<int> ids,
+        CancellationToken cancellationToken)
+    {
+        var workItems = new List<AdoWorkItem>();
+
+        foreach (var batch in ids.Chunk(200))
+        {
+            var idsString = string.Join(",", batch);
+            var response = await client.GetFromJsonAsync<AdoWorkItemListResponse>(
+                $"_apis/wit/workitems?ids={idsString}&api-version={_apiVersion}", JsonOptions, cancellationToken);
+
+            if (response?.Value is not null)
+            {
+                workItems.AddRange(response.Value);
+            }
+        }
+
+        return workItems;
+    }
+
+    /// <summary>
+    /// Projects a work item onto the shared DTO.
+    /// </summary>
+    /// <param name="projectId">
+    /// Must equal what <see cref="GetProjectsAsync"/> reports as <c>ExternalProjectDto.Id</c> — the
+    /// project <i>name</i>, not its GUID. Consumers key stored rows on it. A project-scoped read
+    /// passes the project it asked for; the organisation-wide search reads it back off the work
+    /// item, because it did not name one.
+    /// </param>
+    private static ExternalTaskDto ToExternalTask(AdoWorkItem workItem, string projectId) => new()
+    {
+        Id = workItem.Id.ToString(),
+        Title = workItem.Title,
+        Status = workItem.State,
+        Url = workItem.Url,
+        ProjectId = projectId,
+        Provider = ExternalProvider.AzureDevOps
+    };
 
     private HttpClient CreateClient(string accessToken, string baseUrl)
     {

--- a/Jezda.Common.Integrations.AzureDevOps/Providers/AzureDevOpsTaskProvider.cs
+++ b/Jezda.Common.Integrations.AzureDevOps/Providers/AzureDevOpsTaskProvider.cs
@@ -119,6 +119,79 @@ public sealed class AzureDevOpsTaskProvider(
         })];
     }
 
+    /// <summary>
+    /// Searches work items by title across the whole organisation — one WIQL query plus one details
+    /// batch, instead of the base implementation's query-per-project fan-out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The WIQL omits <c>[System.TeamProject]</c> and the URL omits the project segment, which is
+    /// what makes this organisation-wide. Consequently the project cannot come from a parameter —
+    /// it is read back per work item from <c>System.TeamProject</c>, and matches the value
+    /// <see cref="GetProjectsAsync"/> reports as <c>ExternalProjectDto.Id</c> (the project
+    /// <i>name</i>, not its GUID). Consumers key stored rows on that, so the two must agree.
+    /// </para>
+    /// <para>
+    /// <c>CONTAINS</c> is a substring match on the title only, and is what Azure DevOps can index;
+    /// <c>CONTAINS WORDS</c> would be full-text but requires the search extension to be installed.
+    /// Results come back newest-changed first, which is the useful order for someone looking for
+    /// what they were working on.
+    /// </para>
+    /// </remarks>
+    public async Task<IReadOnlyList<ExternalTaskDto>> SearchTasksAsync(
+        string accessToken,
+        string searchTerm,
+        int limit = 20,
+        string? baseUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseUrl, nameof(baseUrl));
+
+        if (string.IsNullOrWhiteSpace(searchTerm) || limit <= 0)
+        {
+            return [];
+        }
+
+        using var client = CreateClient(accessToken, baseUrl);
+
+        // Same escaping as GetTasksAsync: WIQL string literals are single-quoted, and a quote in
+        // the user's text would otherwise end the literal.
+        var sanitizedTerm = searchTerm.Trim().Replace("'", "''");
+        var wiqlRequest = new AdoWiqlRequest
+        {
+            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.Title] CONTAINS '{sanitizedTerm}' AND [System.State] <> 'Removed' ORDER BY [System.ChangedDate] DESC"
+        };
+
+        var wiqlResponse = await client.PostAsJsonAsync(
+            $"_apis/wit/wiql?api-version={_apiVersion}", wiqlRequest, JsonOptions, cancellationToken);
+        wiqlResponse.EnsureSuccessStatusCode();
+
+        var wiqlResult = await wiqlResponse.Content.ReadFromJsonAsync<AdoWiqlResponse>(JsonOptions, cancellationToken);
+
+        if (wiqlResult?.WorkItems is not { Count: > 0 })
+        {
+            return [];
+        }
+
+        // Trim to `limit` before fetching details: WIQL returns ids only, so the expensive call is
+        // the one below and there is no reason to hydrate rows the caller will discard.
+        var ids = wiqlResult.WorkItems.Take(limit).Select(wi => wi.Id);
+        var idsString = string.Join(",", ids);
+
+        var detailsResponse = await client.GetFromJsonAsync<AdoWorkItemListResponse>(
+            $"_apis/wit/workitems?ids={idsString}&api-version={_apiVersion}", JsonOptions, cancellationToken);
+
+        return [.. (detailsResponse?.Value ?? []).Select(wi => new ExternalTaskDto
+        {
+            Id = wi.Id.ToString(),
+            Title = wi.Title,
+            Status = wi.State,
+            Url = wi.Url,
+            ProjectId = wi.TeamProject,
+            Provider = ExternalProvider.AzureDevOps
+        })];
+    }
+
     private HttpClient CreateClient(string accessToken, string baseUrl)
     {
         var client = httpClientFactory.CreateClient(HttpClientName);

--- a/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
+++ b/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
@@ -50,6 +50,56 @@ public sealed class GitHubIssue
     public DateTimeOffset CreatedAt { get; set; }
 }
 
+/// <summary>
+/// One page of <c>GET /search/issues</c>. The items are ordinary issues plus a
+/// <c>repository_url</c> the plain issues endpoint does not need to send, because there the
+/// repository was in the request path.
+/// </summary>
+public sealed class GitHubIssueSearchResponse
+{
+    [JsonPropertyName("total_count")]
+    public int TotalCount { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<GitHubSearchIssue> Items { get; set; } = [];
+}
+
+public sealed class GitHubSearchIssue
+{
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = string.Empty;
+
+    [JsonPropertyName("html_url")]
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// API URL of the owning repository, e.g. <c>https://api.github.com/repos/jezda-solutions/serp</c>.
+    /// Its last two segments are the <c>owner/repo</c> full name.
+    /// </summary>
+    [JsonPropertyName("repository_url")]
+    public string RepositoryUrl { get; set; } = string.Empty;
+
+    // Same meaning as on GitHubIssue: non-null marks the item as a pull request.
+    [JsonPropertyName("pull_request")]
+    public GitHubPullRequestRef? PullRequest { get; set; }
+}
+
+/// <summary>
+/// Present on a search item only when it is a pull request. GitHub's issue search returns PRs
+/// alongside issues, and a non-null value is what distinguishes them.
+/// </summary>
+public sealed class GitHubPullRequestRef
+{
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+}
+
 public sealed class GitHubUser
 {
     [JsonPropertyName("id")]

--- a/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
+++ b/Jezda.Common.Integrations.GitHub/Models/GitHubModels.cs
@@ -57,9 +57,6 @@ public sealed class GitHubIssue
 /// </summary>
 public sealed class GitHubIssueSearchResponse
 {
-    [JsonPropertyName("total_count")]
-    public int TotalCount { get; set; }
-
     [JsonPropertyName("items")]
     public List<GitHubSearchIssue> Items { get; set; } = [];
 }
@@ -85,7 +82,8 @@ public sealed class GitHubSearchIssue
     [JsonPropertyName("repository_url")]
     public string RepositoryUrl { get; set; } = string.Empty;
 
-    // Same meaning as on GitHubIssue: non-null marks the item as a pull request.
+    // GitHub models a pull request as an issue, so issue search returns both. A non-null value
+    // here is the only thing that distinguishes them.
     [JsonPropertyName("pull_request")]
     public GitHubPullRequestRef? PullRequest { get; set; }
 }

--- a/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
+++ b/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
@@ -127,9 +127,12 @@ public sealed class GitHubTaskProvider(
 
         using var client = CreateClient(accessToken);
 
-        // GitHub counts `per_page` before `is:issue` filtering is visible to us, and we drop pull
-        // requests below, so ask for headroom and trim after. 100 is GitHub's per-page maximum.
-        var perPage = Math.Min(limit * 2, 100);
+        // `is:issue` is applied server-side by the search index, so `per_page` already pages a
+        // pull-request-free result set and asking for headroom would only transfer rows to discard
+        // — search items carry the full issue payload (body, labels, assignees), several KB each.
+        // The filter below stays as a cheap guard, not as the thing `per_page` is sized around.
+        // 100 is GitHub's per-page maximum.
+        var perPage = Math.Min(limit, 100);
         var query = Uri.EscapeDataString($"{searchTerm.Trim()} is:issue involves:@me");
 
         var response = await client.GetFromJsonAsync<GitHubIssueSearchResponse>(
@@ -156,7 +159,9 @@ public sealed class GitHubTaskProvider(
     /// </summary>
     private static string ToFullName(string repositoryUrl)
     {
-        if (string.IsNullOrWhiteSpace(repositoryUrl))
+        // Null is the only case the length check below cannot absorb — "" and whitespace both split
+        // into a single segment and fall through to string.Empty on their own.
+        if (repositoryUrl is null)
         {
             return string.Empty;
         }

--- a/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
+++ b/Jezda.Common.Integrations.GitHub/Providers/GitHubTaskProvider.cs
@@ -85,6 +85,88 @@ public sealed class GitHubTaskProvider(
         })];
     }
 
+    /// <summary>
+    /// Searches issues through GitHub's search API — one request instead of the base
+    /// implementation's one-per-repository fan-out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Scope is <c>involves:@me</c>, which is narrower than <see cref="GetTasksAsync"/>.</b> It
+    /// finds issues the token's user opened, was assigned, was mentioned in, or commented on — not
+    /// every issue in every repository they can read, which is what a <c>user/repos</c> fan-out
+    /// covers. GitHub's search requires a scoping qualifier (an unscoped term searches all of
+    /// GitHub), and the alternative — one <c>repo:</c> qualifier per repository, built from
+    /// <c>user/repos</c> — does not fit inside the 256-character query limit for anyone with a
+    /// realistic number of repositories. For the case this exists to serve, picking a task to log
+    /// time against, "issues I am involved in" is the right set; a task nobody has touched yet is
+    /// the known gap.
+    /// </para>
+    /// <para>
+    /// <b>Rate limits are separate and much tighter</b> — the search API allows 30 requests per
+    /// minute for an authenticated user, against 5,000 per hour for the core API. Callers driving
+    /// this from a text field must debounce.
+    /// </para>
+    /// <para>
+    /// <c>ProjectId</c> is derived from each item's <c>repository_url</c> rather than a parameter,
+    /// and must equal the <c>owner/repo</c> full name <see cref="GetProjectsAsync"/> reports as
+    /// <c>ExternalProjectDto.Id</c> — consumers key stored rows on that value, so a different
+    /// spelling here would store a second row for a task they already have.
+    /// </para>
+    /// </remarks>
+    public async Task<IReadOnlyList<ExternalTaskDto>> SearchTasksAsync(
+        string accessToken,
+        string searchTerm,
+        int limit = 20,
+        string? baseUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm) || limit <= 0)
+        {
+            return [];
+        }
+
+        using var client = CreateClient(accessToken);
+
+        // GitHub counts `per_page` before `is:issue` filtering is visible to us, and we drop pull
+        // requests below, so ask for headroom and trim after. 100 is GitHub's per-page maximum.
+        var perPage = Math.Min(limit * 2, 100);
+        var query = Uri.EscapeDataString($"{searchTerm.Trim()} is:issue involves:@me");
+
+        var response = await client.GetFromJsonAsync<GitHubIssueSearchResponse>(
+            $"search/issues?q={query}&per_page={perPage}", JsonOptions, cancellationToken);
+
+        var items = (response?.Items ?? [])
+            .Where(i => i.PullRequest is null)
+            .Take(limit);
+
+        return [.. items.Select(i => new ExternalTaskDto
+        {
+            Id = i.Number.ToString(),
+            Title = i.Title,
+            Status = i.State,
+            Url = i.HtmlUrl,
+            ProjectId = ToFullName(i.RepositoryUrl),
+            Provider = ExternalProvider.GitHub
+        })];
+    }
+
+    /// <summary>
+    /// Turns <c>https://api.github.com/repos/{owner}/{repo}</c> into <c>{owner}/{repo}</c>, the same
+    /// value <see cref="GetProjectsAsync"/> reports from <c>GitHubRepository.FullName</c>.
+    /// </summary>
+    private static string ToFullName(string repositoryUrl)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryUrl))
+        {
+            return string.Empty;
+        }
+
+        var segments = repositoryUrl.TrimEnd('/').Split('/');
+        return segments.Length >= 2
+            ? $"{segments[^2]}/{segments[^1]}"
+            : string.Empty;
+    }
+
     private static string? GetNextPageUrl(HttpResponseMessage response)
     {
         if (!response.Headers.TryGetValues("Link", out var linkValues))

--- a/Jezda.Common.Integrations.Tests/Providers/AzureDevOpsTaskProviderTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/AzureDevOpsTaskProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Jezda.Common.Integrations.Abstractions.Enums;
 using Jezda.Common.Integrations.AzureDevOps.Configuration;
 using Jezda.Common.Integrations.AzureDevOps.Providers;
@@ -143,5 +144,112 @@ public class AzureDevOpsTaskProviderTests
         var result = await _provider.GetTasksAsync("my-pat", "ProjectA", "https://dev.azure.com/myorg/");
 
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_QueriesTheWholeOrganisation()
+    {
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { queryType = "flat", workItems = Array.Empty<object>() });
+
+        await _provider.SearchTasksAsync("my-pat", "webhook", baseUrl: "https://dev.azure.com/myorg/");
+
+        // No project segment in the path and no [System.TeamProject] in the WHERE clause: that is
+        // what makes this organisation-wide rather than one query per project. The "myorg" segment
+        // is the organisation, and comes from the base address — GetTasksAsync would add a project
+        // segment after it.
+        var request = Assert.Single(_handler.SentRequests);
+        Assert.Equal("/myorg/_apis/wit/wiql", request.RequestUri!.AbsolutePath);
+
+        var wiql = await ReadWiqlQueryAsync(request);
+        Assert.Contains("[System.Title] CONTAINS 'webhook'", wiql);
+        Assert.Contains("[System.State] <> 'Removed'", wiql);
+        Assert.DoesNotContain("System.TeamProject", wiql);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_ReadsProjectFromTheWorkItemNotAParameter()
+    {
+        _handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            queryType = "flat",
+            workItems = new object[] { new { id = 7, url = "https://dev.azure.com/myorg/_apis/wit/workItems/7" } }
+        });
+        _handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            count = 1,
+            value = new object[]
+            {
+                new
+                {
+                    id = 7,
+                    url = "https://dev.azure.com/myorg/_apis/wit/workItems/7",
+                    fields = new Dictionary<string, object>
+                    {
+                        ["System.Title"] = "Fix webhook retry",
+                        ["System.State"] = "Active",
+                        ["System.TeamProject"] = "Platform"
+                    }
+                }
+            }
+        });
+
+        var result = await _provider.SearchTasksAsync("my-pat", "webhook", baseUrl: "https://dev.azure.com/myorg/");
+
+        var task = Assert.Single(result);
+        Assert.Equal("7", task.Id);
+        Assert.Equal("Fix webhook retry", task.Title);
+        Assert.Equal("Active", task.Status);
+        Assert.Equal("Platform", task.ProjectId);
+        Assert.Equal(ExternalProvider.AzureDevOps, task.Provider);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_TrimsIdsBeforeFetchingDetails()
+    {
+        var workItems = Enumerable.Range(1, 10)
+            .Select(n => (object)new { id = n, url = $"https://dev.azure.com/myorg/_apis/wit/workItems/{n}" })
+            .ToArray();
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { queryType = "flat", workItems });
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { count = 0, value = Array.Empty<object>() });
+
+        await _provider.SearchTasksAsync("my-pat", "webhook", limit: 3, baseUrl: "https://dev.azure.com/myorg/");
+
+        // The details call is the expensive one — it must not hydrate rows the caller discards.
+        var detailsQuery = _handler.SentRequests[1].RequestUri!.Query;
+        Assert.Contains("ids=1,2,3", Uri.UnescapeDataString(detailsQuery));
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_EscapesQuotesInTheSearchTerm()
+    {
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { queryType = "flat", workItems = Array.Empty<object>() });
+
+        await _provider.SearchTasksAsync("my-pat", "it's broken", baseUrl: "https://dev.azure.com/myorg/");
+
+        var wiql = await ReadWiqlQueryAsync(_handler.SentRequests[0]);
+        Assert.Contains("CONTAINS 'it''s broken'", wiql);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchTasksAsync_BlankTerm_ReturnsEmptyWithoutQuerying(string term)
+    {
+        var result = await _provider.SearchTasksAsync("my-pat", term, baseUrl: "https://dev.azure.com/myorg/");
+
+        Assert.Empty(result);
+        Assert.Empty(_handler.SentRequests);
+    }
+
+    /// <summary>
+    /// Pulls the WIQL out of the request body. Asserting on the raw JSON does not work: the default
+    /// <c>JavaScriptEncoder</c> escapes <c>'</c> and <c>&lt;&gt;</c> to <c>'</c> / <c><</c>,
+    /// so the query reads nothing like what Azure DevOps receives after parsing.
+    /// </summary>
+    private static async Task<string> ReadWiqlQueryAsync(HttpRequestMessage request)
+    {
+        var body = await request.Content!.ReadAsStringAsync();
+
+        return JsonDocument.Parse(body).RootElement.GetProperty("query").GetString()!;
     }
 }

--- a/Jezda.Common.Integrations.Tests/Providers/AzureDevOpsTaskProviderTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/AzureDevOpsTaskProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Jezda.Common.Integrations.Abstractions;
 using Jezda.Common.Integrations.Abstractions.Enums;
 using Jezda.Common.Integrations.AzureDevOps.Configuration;
 using Jezda.Common.Integrations.AzureDevOps.Providers;
@@ -151,7 +152,11 @@ public class AzureDevOpsTaskProviderTests
     {
         _handler.EnqueueResponse(HttpStatusCode.OK, new { queryType = "flat", workItems = Array.Empty<object>() });
 
-        await _provider.SearchTasksAsync("my-pat", "webhook", baseUrl: "https://dev.azure.com/myorg/");
+        // Through the interface on purpose: SearchTasksAsync is a default interface implementation
+        // that this class overrides implicitly, with no `override` keyword and no diagnostic if the
+        // signature drifts. Calling the concrete method would keep passing after the override had
+        // silently stopped implementing the interface member.
+        await ((IExternalTaskProvider)_provider).SearchTasksAsync("my-pat", "webhook", baseUrl: "https://dev.azure.com/myorg/");
 
         // No project segment in the path and no [System.TeamProject] in the WHERE clause: that is
         // what makes this organisation-wide rather than one query per project. The "myorg" segment
@@ -164,6 +169,68 @@ public class AzureDevOpsTaskProviderTests
         Assert.Contains("[System.Title] CONTAINS 'webhook'", wiql);
         Assert.Contains("[System.State] <> 'Removed'", wiql);
         Assert.DoesNotContain("System.TeamProject", wiql);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_BoundsTheIdQueryServerSide()
+    {
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { queryType = "flat", workItems = Array.Empty<object>() });
+
+        await _provider.SearchTasksAsync("my-pat", "webhook", limit: 5, baseUrl: "https://dev.azure.com/myorg/");
+
+        // Without TOP, a common term against a large organisation returns thousands of refs that
+        // are fetched, parsed, and then thrown away by the Take below.
+        var wiql = await ReadWiqlQueryAsync(_handler.SentRequests[0]);
+        Assert.Contains("SELECT TOP 5 [System.Id]", wiql);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_RestoresTheQueryOrderAfterTheDetailsBatch()
+    {
+        // WIQL sorts newest-changed first; `workitems?ids=` does not contract to answer in the
+        // order the ids were supplied. Here it answers in the opposite order.
+        _handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            queryType = "flat",
+            workItems = new object[]
+            {
+                new { id = 9, url = "https://dev.azure.com/myorg/_apis/wit/workItems/9" },
+                new { id = 3, url = "https://dev.azure.com/myorg/_apis/wit/workItems/3" }
+            }
+        });
+        _handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            count = 2,
+            value = new object[]
+            {
+                new
+                {
+                    id = 3,
+                    url = "https://dev.azure.com/myorg/_apis/wit/workItems/3",
+                    fields = new Dictionary<string, object>
+                    {
+                        ["System.Title"] = "Older",
+                        ["System.State"] = "Active",
+                        ["System.TeamProject"] = "Platform"
+                    }
+                },
+                new
+                {
+                    id = 9,
+                    url = "https://dev.azure.com/myorg/_apis/wit/workItems/9",
+                    fields = new Dictionary<string, object>
+                    {
+                        ["System.Title"] = "Newest",
+                        ["System.State"] = "Active",
+                        ["System.TeamProject"] = "Platform"
+                    }
+                }
+            }
+        });
+
+        var result = await _provider.SearchTasksAsync("my-pat", "webhook", baseUrl: "https://dev.azure.com/myorg/");
+
+        Assert.Equal(["9", "3"], result.Select(t => t.Id));
     }
 
     [Fact]

--- a/Jezda.Common.Integrations.Tests/Providers/FallbackSearchTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/FallbackSearchTests.cs
@@ -76,24 +76,17 @@ public class FallbackSearchTests
     }
 
     [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task BlankTerm_ReturnsEmptyWithoutTouchingTheProvider(string term)
+    [InlineData("", 20)]
+    [InlineData("   ", 20)]
+    [InlineData("match", 0)]
+    [InlineData("match", -1)]
+    public async Task NothingToSearchFor_ReturnsEmptyWithoutTouchingTheProvider(string term, int limit)
     {
-        var provider = new FakeProvider(projects: ["alpha"], tasksByProject: new() { ["alpha"] = [("1", "anything")] });
-
-        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", term);
-
-        Assert.Empty(result);
-        Assert.False(provider.ProjectsRequested);
-    }
-
-    [Fact]
-    public async Task NonPositiveLimit_ReturnsEmptyWithoutTouchingTheProvider()
-    {
+        // A blank term must never become "every task in the account" — that is the enumeration this
+        // whole route exists to stop doing.
         var provider = new FakeProvider(projects: ["alpha"], tasksByProject: new() { ["alpha"] = [("1", "match")] });
 
-        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", "match", limit: 0);
+        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", term, limit);
 
         Assert.Empty(result);
         Assert.False(provider.ProjectsRequested);

--- a/Jezda.Common.Integrations.Tests/Providers/FallbackSearchTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/FallbackSearchTests.cs
@@ -1,0 +1,143 @@
+using Jezda.Common.Integrations.Abstractions;
+using Jezda.Common.Integrations.Abstractions.Enums;
+using Jezda.Common.Integrations.Abstractions.Models;
+using Xunit;
+
+namespace Jezda.Common.Integrations.Tests.Providers;
+
+/// <summary>
+/// Covers the default implementation of <see cref="IExternalTaskProvider.SearchTasksAsync"/> — the
+/// one every provider without a native search inherits (Jira, Trello, ClickUp, Monday).
+/// </summary>
+public class FallbackSearchTests
+{
+    [Fact]
+    public async Task FansOutOverProjectsAndMatchesTitleCaseInsensitively()
+    {
+        IExternalTaskProvider provider = new FakeProvider(
+            projects: ["alpha", "beta"],
+            tasksByProject: new()
+            {
+                ["alpha"] = [("1", "Fix WEBHOOK retry"), ("2", "Unrelated")],
+                ["beta"] = [("3", "webhook cleanup")]
+            });
+
+        var result = await provider.SearchTasksAsync("token", "webhook");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(["1", "3"], result.Select(t => t.Id));
+        // ProjectId survives the fan-out — it is what a consumer keys a stored row on.
+        Assert.Equal("alpha", result[0].ProjectId);
+        Assert.Equal("beta", result[1].ProjectId);
+    }
+
+    [Fact]
+    public async Task MatchesOnExternalIdAsWellAsTitle()
+    {
+        IExternalTaskProvider provider = new FakeProvider(
+            projects: ["alpha"],
+            tasksByProject: new() { ["alpha"] = [("412", "Nothing to do with the term")] });
+
+        var result = await provider.SearchTasksAsync("token", "412");
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task StopsCallingProjectsOnceTheLimitIsReached()
+    {
+        var provider = new FakeProvider(
+            projects: ["alpha", "beta", "gamma"],
+            tasksByProject: new()
+            {
+                ["alpha"] = [("1", "match"), ("2", "match")],
+                ["beta"] = [("3", "match")],
+                ["gamma"] = [("4", "match")]
+            });
+
+        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", "match", limit: 2);
+
+        Assert.Equal(2, result.Count);
+        // Every extra project is another HTTP round trip nobody is waiting for: after "alpha"
+        // filled the limit, "beta" and "gamma" must not be fetched.
+        Assert.Equal(["alpha"], provider.RequestedProjects);
+    }
+
+    [Fact]
+    public async Task TrimsOverflowFromTheLastProjectToTheLimit()
+    {
+        IExternalTaskProvider provider = new FakeProvider(
+            projects: ["alpha"],
+            tasksByProject: new() { ["alpha"] = [("1", "match"), ("2", "match"), ("3", "match")] });
+
+        var result = await provider.SearchTasksAsync("token", "match", limit: 2);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BlankTerm_ReturnsEmptyWithoutTouchingTheProvider(string term)
+    {
+        var provider = new FakeProvider(projects: ["alpha"], tasksByProject: new() { ["alpha"] = [("1", "anything")] });
+
+        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", term);
+
+        Assert.Empty(result);
+        Assert.False(provider.ProjectsRequested);
+    }
+
+    [Fact]
+    public async Task NonPositiveLimit_ReturnsEmptyWithoutTouchingTheProvider()
+    {
+        var provider = new FakeProvider(projects: ["alpha"], tasksByProject: new() { ["alpha"] = [("1", "match")] });
+
+        var result = await ((IExternalTaskProvider)provider).SearchTasksAsync("token", "match", limit: 0);
+
+        Assert.Empty(result);
+        Assert.False(provider.ProjectsRequested);
+    }
+
+    /// <summary>
+    /// Implements only the three original members, so <c>SearchTasksAsync</c> resolves to the
+    /// interface's default body — which is exactly what is under test.
+    /// </summary>
+    private sealed class FakeProvider(
+        List<string> projects,
+        Dictionary<string, List<(string Id, string Title)>> tasksByProject) : IExternalTaskProvider
+    {
+        public List<string> RequestedProjects { get; } = [];
+
+        public bool ProjectsRequested { get; private set; }
+
+        public ExternalProvider Provider => ExternalProvider.Jira;
+
+        public Task<bool> ValidateConnectionAsync(string accessToken, string? baseUrl = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<IReadOnlyList<ExternalProjectDto>> GetProjectsAsync(string accessToken, string? baseUrl = null, CancellationToken cancellationToken = default)
+        {
+            ProjectsRequested = true;
+
+            return Task.FromResult<IReadOnlyList<ExternalProjectDto>>(
+                [.. projects.Select(p => new ExternalProjectDto { Id = p, Name = p, Provider = ExternalProvider.Jira })]);
+        }
+
+        public Task<IReadOnlyList<ExternalTaskDto>> GetTasksAsync(string accessToken, string projectId, string? baseUrl = null, CancellationToken cancellationToken = default)
+        {
+            RequestedProjects.Add(projectId);
+
+            var tasks = tasksByProject.TryGetValue(projectId, out var t) ? t : [];
+
+            return Task.FromResult<IReadOnlyList<ExternalTaskDto>>(
+                [.. tasks.Select(x => new ExternalTaskDto
+                {
+                    Id = x.Id,
+                    Title = x.Title,
+                    ProjectId = projectId,
+                    Provider = ExternalProvider.Jira
+                })]);
+        }
+    }
+}

--- a/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
@@ -107,4 +107,121 @@ public class GitHubTaskProviderTests
         Assert.Equal("100", queryParams["per_page"]);
         Assert.Contains("repos/owner/repo/issues", requestUri.AbsolutePath);
     }
+
+    [Fact]
+    public async Task SearchTasksAsync_UsesSearchApiInOneRequest()
+    {
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { total_count = 0, items = Array.Empty<object>() });
+
+        await _provider.SearchTasksAsync("token", "webhook");
+
+        // The whole point of the override: one call, not GetProjects + GetTasks per repository.
+        Assert.Single(_handler.SentRequests);
+
+        var requestUri = _handler.SentRequests[0].RequestUri!;
+        Assert.Contains("search/issues", requestUri.AbsolutePath);
+
+        var query = Uri.UnescapeDataString(requestUri.Query);
+        Assert.Contains("webhook", query);
+        Assert.Contains("is:issue", query);
+        Assert.Contains("involves:@me", query);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_DerivesProjectIdFromRepositoryUrl()
+    {
+        // ProjectId must be the owner/repo full name GetProjectsAsync reports, because consumers
+        // key stored rows on that value.
+        var response = new
+        {
+            total_count = 1,
+            items = new object[]
+            {
+                new
+                {
+                    number = 412,
+                    title = "Fix webhook retry",
+                    state = "open",
+                    html_url = "https://github.com/jezda-solutions/serp/issues/412",
+                    repository_url = "https://api.github.com/repos/jezda-solutions/serp"
+                }
+            }
+        };
+        _handler.EnqueueResponse(HttpStatusCode.OK, response);
+
+        var result = await _provider.SearchTasksAsync("token", "webhook");
+
+        var task = Assert.Single(result);
+        Assert.Equal("412", task.Id);
+        Assert.Equal("Fix webhook retry", task.Title);
+        Assert.Equal("open", task.Status);
+        Assert.Equal("https://github.com/jezda-solutions/serp/issues/412", task.Url);
+        Assert.Equal("jezda-solutions/serp", task.ProjectId);
+        Assert.Equal(ExternalProvider.GitHub, task.Provider);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_ExcludesPullRequests()
+    {
+        var response = new
+        {
+            total_count = 2,
+            items = new object[]
+            {
+                new
+                {
+                    number = 1,
+                    title = "Real issue",
+                    state = "open",
+                    html_url = "https://github.com/owner/repo/issues/1",
+                    repository_url = "https://api.github.com/repos/owner/repo"
+                },
+                new
+                {
+                    number = 2,
+                    title = "A pull request",
+                    state = "open",
+                    html_url = "https://github.com/owner/repo/pull/2",
+                    repository_url = "https://api.github.com/repos/owner/repo",
+                    pull_request = new { url = "https://api.github.com/repos/owner/repo/pulls/2" }
+                }
+            }
+        };
+        _handler.EnqueueResponse(HttpStatusCode.OK, response);
+
+        var result = await _provider.SearchTasksAsync("token", "issue");
+
+        var task = Assert.Single(result);
+        Assert.Equal("1", task.Id);
+    }
+
+    [Fact]
+    public async Task SearchTasksAsync_TrimsToLimit()
+    {
+        var items = Enumerable.Range(1, 10).Select(n => (object)new
+        {
+            number = n,
+            title = $"Issue {n}",
+            state = "open",
+            html_url = $"https://github.com/owner/repo/issues/{n}",
+            repository_url = "https://api.github.com/repos/owner/repo"
+        }).ToArray();
+        _handler.EnqueueResponse(HttpStatusCode.OK, new { total_count = 10, items });
+
+        var result = await _provider.SearchTasksAsync("token", "issue", limit: 3);
+
+        Assert.Equal(3, result.Count);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchTasksAsync_BlankTerm_ReturnsEmptyWithoutCallingGitHub(string term)
+    {
+        // A blank term must never become "every issue I am involved in".
+        var result = await _provider.SearchTasksAsync("token", term);
+
+        Assert.Empty(result);
+        Assert.Empty(_handler.SentRequests);
+    }
 }

--- a/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
+++ b/Jezda.Common.Integrations.Tests/Providers/GitHubTaskProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Jezda.Common.Integrations.Abstractions;
 using Jezda.Common.Integrations.Abstractions.Enums;
 using Jezda.Common.Integrations.GitHub.Providers;
 using Jezda.Common.Integrations.Tests.Helpers;
@@ -113,7 +114,12 @@ public class GitHubTaskProviderTests
     {
         _handler.EnqueueResponse(HttpStatusCode.OK, new { total_count = 0, items = Array.Empty<object>() });
 
-        await _provider.SearchTasksAsync("token", "webhook");
+        // Deliberately called through the interface. SearchTasksAsync is a default interface
+        // implementation that this class overrides implicitly — there is no `override` keyword and
+        // no compiler diagnostic, so if the interface signature ever changes the concrete method
+        // silently stops implementing it and every caller falls back to the fan-out. Through the
+        // interface, the single-request assertion below is what catches that.
+        await ((IExternalTaskProvider)_provider).SearchTasksAsync("token", "webhook");
 
         // The whole point of the override: one call, not GetProjects + GetTasks per repository.
         Assert.Single(_handler.SentRequests);


### PR DESCRIPTION
Prerequisite for jezda-solutions/jezda-platform#1683, which retires TMS's permanent external-task sync in favour of searching the provider when a user opens the task picker.

## Why

`IExternalTaskProvider` could list projects and list a project's tasks, but it could not **search**. "Find me the task I'm about to log time against" therefore meant enumerating every project and filtering locally — one HTTP round trip per project, far too slow to sit behind a keystroke. That is why consumers cached the entire task list in a background job instead, and that background job is what #1683 is removing.

## What

`SearchTasksAsync` ships as a **default interface implementation** that fans out over `GetProjectsAsync` + `GetTasksAsync` and filters in memory. Six types implement this interface; the DIM keeps Jira, Trello, ClickUp and Monday compiling and working unchanged. It is documented as `1 + N` requests, with a note that any provider able to search server-side should override it.

Two do:

| Provider | Implementation | Requests |
|---|---|---|
| GitHub | `GET /search/issues?q={term}+is:issue+involves:@me` | 1 |
| Azure DevOps | organisation-wide WIQL `[System.Title] CONTAINS`, then the existing details batch | 2 |

### Two caveats recorded in the XML docs, not hidden

- **GitHub's scope is narrower than a `user/repos` fan-out.** `involves:@me` finds issues the user opened, was assigned, was mentioned in, or commented on — not every issue in every repository they can read. GitHub search requires a scoping qualifier, and one `repo:` qualifier per repository does not fit inside the 256-character query limit.
- **GitHub's search rate limit is much tighter** — 30 requests/minute against 5,000/hour for the core API. Callers driving this from a text field must debounce.

### One thing that would break consumers silently

Both overrides map `ExternalTaskDto.ProjectId` to the same value `GetProjectsAsync` reports as `ExternalProjectDto.Id` — `owner/repo` for GitHub, the project **name** for Azure DevOps. Consumers key stored rows on that value, so a different spelling here would store a second row for a task they already have rather than reuse it.

GitHub's search response does not carry it directly, so it is derived from `repository_url`. Azure DevOps cannot take it from a parameter (the query is not project-scoped), so `AdoWorkItem` gains a `TeamProject` helper beside the existing `Title` and `State`.

## Tests

21 new, 88 total green.

- Per provider: request shape, project-id derivation, pull-request exclusion, limit trimming, WIQL quote escaping, blank-term guard.
- The fallback: fan-out across projects, case-insensitive title and id matching, short-circuit once the limit is filled (asserting later projects are never fetched), and the blank-term/non-positive-limit guards.

## Release

Needs publishing as **1.2.0** — `jezda-platform` pins that version to consume it.

## Note on the base

Branched off `master`, not off `fix/github-exclude-pull-requests`. That branch is still open and predates the .NET 10 upgrade (#138); the two touch `GitHubModels.cs` near each other, so expect a small conflict whichever merges second. `GitHubPullRequestRef` is defined here because `GitHubSearchIssue` needs it.